### PR TITLE
Fix error text appearance

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.Design">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>


### PR DESCRIPTION
It turns out `errorTextAppearance` doesn't work in the *design* support library if you are using an *app compat* theme.

Found it by poking through `TextInputLayout`. This is on L637:

```
if (Build.VERSION.SDK_INT >= 23
        && mErrorView.getTextColors().getDefaultColor() == Color.MAGENTA) {
    // Caused by our theme not extending from Theme.Design*. On API 23 and
    // above, unresolved theme attrs result in MAGENTA rather than an exception.
    // Flag so that we use a decent default
    useDefaultColor = true;
}
```